### PR TITLE
Improve error handling of Ab Initio calculations

### DIFF
--- a/src/pathfinder.f90
+++ b/src/pathfinder.f90
@@ -2605,6 +2605,13 @@ contains
         endif
 
         call AbInitio(wcx(1), 'optg', success)
+		if (.not. success) then
+		  err = .true.
+		  errstr = 'Reactant optimisation failed'
+		  wcx(1)%r(:, :) = rstore(:, :)
+          wcx(1)%graph(:,:) = grstore(:, :)
+          return
+		endif
 
         ! Check graph hasn't been invalidated by optimisation.
         ! Note that this is not subject to user decision, as an incorrect graph
@@ -2631,6 +2638,11 @@ contains
 
       else
         call AbInitio(wcx(1), 'ener', success)
+		if (.not. success) then
+		  err = .true.
+		  errstr = 'Energy calculation for reactant failed'
+		  return
+		endif
       endif
     endif
 
@@ -2673,6 +2685,14 @@ contains
       grstore(:,:) = wcx(2)%graph(:,:)
 
       call AbInitio(wcx(2), 'optg', success)
+	  if (.not. success) then
+		err = .true.
+		errstr = 'Product optimisation failed'
+		wcx(2)%r(:, :) = wcx(1)%r(:, :)
+		wcx(2)%graph(:, :) = grstore(:, :)
+		return
+	  endif
+
       call SetCXSconstraints(wcx(2), NDOFconstr, FixedDOF, Natomconstr, FixedAtom)
 
       call GetGraph(wcx(2))

--- a/src/pathfinder.f90
+++ b/src/pathfinder.f90
@@ -2605,13 +2605,13 @@ contains
         endif
 
         call AbInitio(wcx(1), 'optg', success)
-		if (.not. success) then
-		  err = .true.
-		  errstr = 'Reactant optimisation failed'
-		  wcx(1)%r(:, :) = rstore(:, :)
+        if (.not. success) then
+          err = .true.
+          errstr = 'Reactant optimisation failed'
+          wcx(1)%r(:, :) = rstore(:, :)
           wcx(1)%graph(:,:) = grstore(:, :)
           return
-		endif
+        endif
 
         ! Check graph hasn't been invalidated by optimisation.
         ! Note that this is not subject to user decision, as an incorrect graph
@@ -2638,11 +2638,11 @@ contains
 
       else
         call AbInitio(wcx(1), 'ener', success)
-		if (.not. success) then
-		  err = .true.
-		  errstr = 'Energy calculation for reactant failed'
-		  return
-		endif
+        if (.not. success) then
+          err = .true.
+          errstr = 'Energy calculation for reactant failed'
+          return
+        endif
       endif
     endif
 
@@ -2685,13 +2685,13 @@ contains
       grstore(:,:) = wcx(2)%graph(:,:)
 
       call AbInitio(wcx(2), 'optg', success)
-	  if (.not. success) then
-		err = .true.
-		errstr = 'Product optimisation failed'
-		wcx(2)%r(:, :) = wcx(1)%r(:, :)
-		wcx(2)%graph(:, :) = grstore(:, :)
-		return
-	  endif
+      if (.not. success) then
+        err = .true.
+        errstr = 'Product optimisation failed'
+        wcx(2)%r(:, :) = wcx(1)%r(:, :)
+        wcx(2)%graph(:, :) = grstore(:, :)
+        return
+      endif
 
       call SetCXSconstraints(wcx(2), NDOFconstr, FixedDOF, Natomconstr, FixedAtom)
 

--- a/src/pathopt.f90
+++ b/src/pathopt.f90
@@ -31,7 +31,7 @@ contains
     type(rxp), intent(out) :: rp
 
     integer :: nmol(2)
-    logical :: ldum
+    logical :: success
 
     ! Initialize the reaction path object.
     Call NewPath(rp, startfrompath, startfile, endfile, pathfile, nimage, &
@@ -69,8 +69,16 @@ contains
 
       ! Do we optimize the end-points before NEB?
       if (optendsbefore) then
-        call AbInitio(rp%cx(1), 'optg', ldum)
-        call AbInitio(rp%cx(rp%nimage), 'optg', ldum)
+        call AbInitio(rp%cx(1), 'optg', success)
+		if (.not. success) then
+		  stop "* ERROR: Optimization of the initial geometry failed"
+		endif
+
+        call AbInitio(rp%cx(rp%nimage), 'optg', success)
+		if (.not. success) then
+		  stop "* ERROR: Optimization of the final geometry failed"
+		endif
+
         call GetGraph(rp%cx(1))
         call GetMols(rp%cx(1))
         call GetGraph(rp%cx(rp%nimage))
@@ -199,8 +207,16 @@ contains
     ! Do we optimize the end-points before NEB?
     !
     if (optendsbefore) then
-      call AbInitio(rp%cx(1), 'optg', ldum)
-      call AbInitio(rp%cx(rp%nimage), 'optg', ldum)
+      call AbInitio(rp%cx(1), 'optg', success)
+	  if (.not. success) then
+		stop "* ERROR: Optimization of the initial geometry failed"
+	  endif
+
+      call AbInitio(rp%cx(rp%nimage), 'optg', success)
+	  if (.not. success) then
+		stop "* ERROR: Optimization of the final geometry failed"
+	  endif
+
       call GetGraph(rp%cx(1))
       call GetMols(rp%cx(1))
       call GetGraph(rp%cx(rp%nimage))

--- a/src/pathopt.f90
+++ b/src/pathopt.f90
@@ -291,6 +291,9 @@ contains
     ! Calculate the energy along the initial path.
     !
     call GetPathGradients(rp, success, .true.)
+	if (.not. success) then
+	  stop '* ERROR: Gradient calculation failed.'
+	endif
 
     ! Add restraint forces to end-points if required.
     !
@@ -474,6 +477,9 @@ contains
       ! Recalculate energy and projected forces.
       !
       call GetPathGradients(rp, success, .false.)
+	  if (.not. success) then
+		stop '* ERROR: Gradient re-calculation (following optimisation) failed.'
+	  endif
 
       ! Remove overall translation and rotation.
       ! TBD

--- a/src/pathopt.f90
+++ b/src/pathopt.f90
@@ -70,14 +70,14 @@ contains
       ! Do we optimize the end-points before NEB?
       if (optendsbefore) then
         call AbInitio(rp%cx(1), 'optg', success)
-		if (.not. success) then
-		  stop "* ERROR: Optimization of the initial geometry failed"
-		endif
+        if (.not. success) then
+          stop "* ERROR: Optimization of the initial geometry failed"
+        endif
 
         call AbInitio(rp%cx(rp%nimage), 'optg', success)
-		if (.not. success) then
-		  stop "* ERROR: Optimization of the final geometry failed"
-		endif
+        if (.not. success) then
+          stop "* ERROR: Optimization of the final geometry failed"
+        endif
 
         call GetGraph(rp%cx(1))
         call GetMols(rp%cx(1))
@@ -208,14 +208,14 @@ contains
     !
     if (optendsbefore) then
       call AbInitio(rp%cx(1), 'optg', success)
-	  if (.not. success) then
-		stop "* ERROR: Optimization of the initial geometry failed"
-	  endif
+      if (.not. success) then
+        stop "* ERROR: Optimization of the initial geometry failed"
+      endif
 
       call AbInitio(rp%cx(rp%nimage), 'optg', success)
-	  if (.not. success) then
-		stop "* ERROR: Optimization of the final geometry failed"
-	  endif
+      if (.not. success) then
+        stop "* ERROR: Optimization of the final geometry failed"
+      endif
 
       call GetGraph(rp%cx(1))
       call GetMols(rp%cx(1))
@@ -291,9 +291,9 @@ contains
     ! Calculate the energy along the initial path.
     !
     call GetPathGradients(rp, success, .true.)
-	if (.not. success) then
-	  stop '* ERROR: Gradient calculation failed.'
-	endif
+    if (.not. success) then
+      stop '* ERROR: Gradient calculation failed.'
+    endif
 
     ! Add restraint forces to end-points if required.
     !
@@ -477,9 +477,9 @@ contains
       ! Recalculate energy and projected forces.
       !
       call GetPathGradients(rp, success, .false.)
-	  if (.not. success) then
-		stop '* ERROR: Gradient re-calculation (following optimisation) failed.'
-	  endif
+      if (.not. success) then
+        stop '* ERROR: Gradient re-calculation (following optimisation) failed.'
+      endif
 
       ! Remove overall translation and rotation.
       ! TBD

--- a/src/pes.f90
+++ b/src/pes.f90
@@ -776,7 +776,8 @@ contains
       inquire(file="temp.engrad", exist=there)
       if (.not. there) then
         print *, 'Missing file temp.engrad, ORCA calculation must have failed.'
-        stop 
+        success = .FALSE.
+        return 
       endif
       string1 = "grep 'The current gradient' temp.engrad -A"
       write(cnum,'(I5)')3*cx%na+2

--- a/src/rpath.f90
+++ b/src/rpath.f90
@@ -717,6 +717,7 @@ contains
     type(rxp) :: rp
     integer :: i
     logical :: minimize, success
+	character(len=50) :: errstr
 
     ! Loop over images, calculating energy for each.
     !
@@ -726,6 +727,13 @@ contains
         call GetMols(rp%cx(i))
       endif
       call AbInitio(rp%cx(i), 'ener', success)
+
+	  if (.not. success) then
+		errstr = 'Energy calculation failed for image '
+		write(errstr, '(I5)') i
+		print *, errstr
+		return
+	  endif
     enddo
 
     return
@@ -751,6 +759,7 @@ contains
     logical, intent(out) :: success
     logical, intent(in) :: calc_all
     integer :: i
+	character(len=50) :: errstr
 
     ! Loop over images, calculating energy for each.
     !
@@ -762,6 +771,13 @@ contains
         call GetMols(rp%cx(i))
       endif
       call AbInitio(rp%cx(i), 'grad', success)
+
+	  if (.not. success) then
+		errstr = 'Gradient calculation failed for image '
+		write(errstr, '(I5)') i
+		print *, errstr
+		return
+	  endif
     enddo
 
     return

--- a/src/rpath.f90
+++ b/src/rpath.f90
@@ -717,7 +717,7 @@ contains
     type(rxp) :: rp
     integer :: i
     logical :: minimize, success
-	character(len=50) :: errstr
+	  character(len=50) :: errstr
 
     ! Loop over images, calculating energy for each.
     !
@@ -728,12 +728,12 @@ contains
       endif
       call AbInitio(rp%cx(i), 'ener', success)
 
-	  if (.not. success) then
-		errstr = 'Energy calculation failed for image '
-		write(errstr, '(I5)') i
-		print *, errstr
-		return
-	  endif
+      if (.not. success) then
+        errstr = 'Energy calculation failed for image '
+        write(errstr, '(I5)') i
+        print *, errstr
+        return
+      endif
     enddo
 
     return
@@ -759,7 +759,7 @@ contains
     logical, intent(out) :: success
     logical, intent(in) :: calc_all
     integer :: i
-	character(len=50) :: errstr
+	  character(len=50) :: errstr
 
     ! Loop over images, calculating energy for each.
     !
@@ -772,12 +772,12 @@ contains
       endif
       call AbInitio(rp%cx(i), 'grad', success)
 
-	  if (.not. success) then
-		errstr = 'Gradient calculation failed for image '
-		write(errstr, '(I5)') i
-		print *, errstr
-		return
-	  endif
+      if (.not. success) then
+        errstr = 'Gradient calculation failed for image '
+        write(errstr, '(I5)') i
+        print *, errstr
+        return
+      endif
     enddo
 
     return


### PR DESCRIPTION
Error handling of _ab initio_ calculaions has been improved:

1. The failure of ORCA calculations no longer ends the cde run and instead returns `success=.false.`
2. success checks have been added to `GraphsToCoords_BD` subroutine after every call to `AbInitio`, resulting in early interruption and cycling of `RunBreakDown`.  (I haven't changed `GraphsToCoords` subroutine since it doesn't seem to have any error handling built in)
3. success checks have been added to `InterpolatePath` and `CINEB` subroutines after every `AbInitio` and `GetPathGradients` calls; any failure in any of these results in early termination of CDE with an error
4. success checks have been added to `GetPathGradients` and `GetPathEnergy` sybroutines after `AbInitio` calls; any failure prints to stdout and early aborts.

Please have a look and let me know if anything needs changing.