### PR TITLE
More AbInitio error handling fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/modfiles
 bin
 test/*
+doc/*

--- a/src/pathfinder.f90
+++ b/src/pathfinder.f90
@@ -2605,6 +2605,14 @@ contains
         endif
 
         call AbInitio(wcx(1), 'optg', success)
+        if (.not. success) then
+          err = .TRUE.
+          errstr = 'Optimisation of reactant failed'
+          wcx(1)%r(:, :) = rstore(:, :)
+          wcx(1)%graph(:, :) = grstore(:, :)
+          call GetMols(wcx(1))
+          return
+        endif
 
         ! Check graph hasn't been invalidated by optimisation.
         ! Note that this is not subject to user decision, as an incorrect graph
@@ -2631,6 +2639,11 @@ contains
 
       else
         call AbInitio(wcx(1), 'ener', success)
+        if (.not. success) then
+          err = .TRUE.
+          errstr = 'Energy calculation of reactant failed'
+          return
+        endif
       endif
     endif
 
@@ -2671,8 +2684,17 @@ contains
     !
     if (optaftermove .and. optoverride_aux) then
       grstore(:,:) = wcx(2)%graph(:,:)
+      rstore(:, :) = wcx(2)%r(:, :)
 
       call AbInitio(wcx(2), 'optg', success)
+      if (.not. success) then
+        err = .TRUE.
+        errstr = 'Optimisation of product failed'
+        wcx(2)%r(:, :) = rstore(:, :)
+        wcx(2)%graph(:, :) = grstore(:, :)
+        call GetMols(wcx(2))
+        return
+      endif
       call SetCXSconstraints(wcx(2), NDOFconstr, FixedDOF, Natomconstr, FixedAtom)
 
       call GetGraph(wcx(2))

--- a/src/pes.f90
+++ b/src/pes.f90
@@ -177,7 +177,7 @@ contains
   !
   Subroutine AbInitio(cx, abtypein, success)
     implicit none
-    logical :: minimize, minimize_mol, success
+    logical :: minimize, minimize_mol, success, success_mol
     type(cxs) :: cx
     type(cxs), dimension(:), allocatable :: cxtemp
     character (len=6) :: ptype
@@ -291,6 +291,7 @@ contains
 
       ! For each CXS object, calculate the energy.
       !
+      success = .true.
       do i = 1, nmol
 
         print *, 'Optimising molecule ', i, "/", nmol
@@ -302,33 +303,34 @@ contains
           abtype_mol = abtype
           minimize_mol = minimize
         endif
+        success_mol = .true.
 
         ! Run the calculation.
         select case (ptype)
 
           case('orca')
-            call ORCAcalc(cxtemp(i), abtype_mol, success)
+            call ORCAcalc(cxtemp(i), abtype_mol, success_mol)
 
           case('dftb')
-            call DFTBcalc(cxtemp(i), minimize_mol, success)
+            call DFTBcalc(cxtemp(i), minimize_mol, success_mol)
 
           case('lammps')
-            call LAMMPScalc(cxtemp(i), abtype_mol, success)
+            call LAMMPScalc(cxtemp(i), abtype_mol, success_mol)
 
           case('psi4')
-            call PSI4calc(cxtemp(i), minimize_mol, success)
+            call PSI4calc(cxtemp(i), minimize_mol, success_mol)
 
           case('molpro')
-            call MOLPROcalc(cxtemp(i), abtype_mol, success)
+            call MOLPROcalc(cxtemp(i), abtype_mol, success_mol)
 
           case('uff')
-            call UFFcalc(cxtemp(i), minimize_mol, success)
+            call UFFcalc(cxtemp(i), minimize_mol, success_mol)
 
           case('xtb')
-            call xTBcalc(cxtemp(i), minimize_mol, success)
+            call xTBcalc(cxtemp(i), minimize_mol, success_mol)
 
           case('aims')
-            call AIMScalc(cxtemp(i), minimize_mol, success)
+            call AIMScalc(cxtemp(i), minimize_mol, success_mol)
 
           case('null')
             cxtemp(i)%vcalc = 0.d0
@@ -339,8 +341,23 @@ contains
 
         end select
 
-        print *, 'Finished optimisation.'
+        if (.not. success_mol) then
+          print *, 'Optimisation of molecule ', i, 'failed.'
+          print *, 'Cancelling remaining optimisations.'
+          success = .false.
+          exit
+        else
+          print *, 'Finished optimisation.'
+        endif
       enddo
+
+      if (.not. success) then
+        do i = 1, nmol
+          call DeleteCXS(cxtemp(i))
+        enddo
+        deallocate(cxtemp)
+        return
+      endif
 
       ! Now recombine the results for each molecule.
       !

--- a/src/pes.f90
+++ b/src/pes.f90
@@ -1040,9 +1040,14 @@ contains
     call execute_command_line(str, wait=.true., exitstat=estat, cmdstat=cstat, cmdmsg=cmsg)
 
     ! Check calculation ran correctly.
-    if (cstat .gt. 0) then
+    if (estat .gt. 0) then
       print *, 'xTB failed with error message: ', cmsg
-      stop
+      success = .false.
+      call execute_command_line(&
+        'rm -f charges xtbin.engrad xtbin.xyz xtbopt.xyz xtbopt.log xtb.out &
+        &energy gradient wbo xtbrestart xtbtopo.mol .xtboptok', &
+        wait=.true., exitstat=estat, cmdstat=cstat, cmdmsg=cmsg)
+      return
     endif
 
     ! Read forces.


### PR DESCRIPTION
A couple of extra fixes to enable fewer hard crashes due to failed `AbInitio` calculations, instead allowing calculations to fail gracefully and retry if applicable. PR applies mainly to the `RunBreakdown` routine, where accepted valid graph moves that produce failed `AbInitio` calculations now properly revert the relevant graphs and fall back to sampling a new graph move.

`pesfull .false.` calculations now have proper failure detection which minimises unnecessary calculation.